### PR TITLE
Don't add empty ? to redirected URLs

### DIFF
--- a/src/services/Redirects.php
+++ b/src/services/Redirects.php
@@ -175,7 +175,9 @@ class Redirects extends Component
             $dest = $redirect['redirectDestUrl'];
             if (Retour::$settings->preserveQueryString) {
                 $request = Craft::$app->getRequest();
-                $dest .= '?' . $request->getQueryString();
+                if (!empty($request->getQueryString())) {
+                    $dest .= '?' . $request->getQueryString();
+                }
             }
             $status = $redirect['redirectHttpCode'];
             Craft::info(


### PR DESCRIPTION
Only add ? to redirected URLs when there is a query string to add.