### PR TITLE
Record the user IP instead of Proxy IP

### DIFF
--- a/src/services/Statistics.php
+++ b/src/services/Statistics.php
@@ -134,7 +134,7 @@ class Statistics extends Component
         if (!$request->isConsoleRequest) {
             $referrer = $request->getReferrer();
             if (Retour::$settings->recordRemoteIp) {
-                $remoteIp = $request->getRemoteIP();
+                $remoteIp = $request->getUserIP();
             }
             $userAgent = $request->getUserAgent();
             if (Retour::$currentException !== null) {


### PR DESCRIPTION
When recording IP's the old method will record the reverse proxy address instead of the user IP when a reverse proxy is being used. 
Using this method the real user's IP will be recorded.