### PR TITLE
handle addTrailingSlashesToUrls config setting

### DIFF
--- a/src/Retour.php
+++ b/src/Retour.php
@@ -496,6 +496,10 @@ class Retour extends Plugin
                     }
                     // Make sure the URIs are not the same
                     if (strcmp($oldUri, $newUri) !== 0) {
+                        // Handle trailing slash config setting
+                        if (Craft::$app->config->general->addTrailingSlashesToUrls) {
+                          $newUri = $newUri . '/';
+                        }
                         $redirectConfig = [
                             'id' => 0,
                             'redirectMatchType' => 'exactmatch',

--- a/src/Retour.php
+++ b/src/Retour.php
@@ -498,7 +498,8 @@ class Retour extends Plugin
                     if (strcmp($oldUri, $newUri) !== 0) {
                         // Handle trailing slash config setting
                         if (Craft::$app->config->general->addTrailingSlashesToUrls) {
-                          $newUri = $newUri . '/';
+                            $oldUri = $oldUri . '/';
+                            $newUri = $newUri . '/';
                         }
                         $redirectConfig = [
                             'id' => 0,


### PR DESCRIPTION
We've been finding an issue where when updating an entry the URI was saved without a trailing slash, which is also forced server-side in the nginx config (pre-getting to craft) causing the redirect to fail when an entry slug is updated as it doesn't match the forced trailing slash pattern.

This PR is one proposal on how this could be handled. Perhaps a better way would be to save these as regex matches with `\/?` at the end instead so that it'll handle either match?