### PR TITLE
Parse destination refs

### DIFF
--- a/src/services/Redirects.php
+++ b/src/services/Redirects.php
@@ -228,6 +228,7 @@ class Redirects extends Component
                     $dest .= '?' . $request->getQueryStringWithoutPath();
                 }
             }
+            $dest = Craft::$app->elements->parseRefs($dest, $redirect['siteId'] ?? null);
             $status = $redirect['redirectHttpCode'];
             Craft::info(
                 Craft::t(


### PR DESCRIPTION
A lot of times I'm setting up a vanity URL or redirect that should always point to a specific entry in Craft. E.g., `/my-awesome-product` should always point to `{entry:123:uri}` because it's a vanity URL to the deeper page of `/products/category/product-slug`. I don't really want to set the destination to the full URI because the URI could change at some point in the future. If I could set the destination to the entry by element ID then I'd have confidence that if the slug/URI of the entry changes in the future the redirect changes too.

This PR adds `parseRefs` to the destination which allows you to set destinations as `/{entry:123:uri}` and have that correctly parsed before the `Location:` header is sent back.

This is a bit of WIP because you'd probably want a setting to control this feature and you'd probably need some safety around how this could be abused, but curious to get your thoughts.