### PR TITLE
Fixes an issue where UrlHelper::sanitizeUrl() would return an empty string

### DIFF
--- a/src/helpers/UrlHelper.php
+++ b/src/helpers/UrlHelper.php
@@ -37,7 +37,7 @@ class UrlHelper extends CraftUrlHelper
         $url = strip_tags($url);
         // Remove any Twig tags that somehow are present in the incoming URL
         /** @noinspection CallableParameterUseCaseInTypeContextInspection */
-        $url = preg_replace('{.*}', '', $url);
+        $url = preg_replace('/{.*}/', '', $url);
 
         return $url;
     }


### PR DESCRIPTION
Should resolve https://github.com/nystudio107/craft-retour/issues/104