### PR TITLE
Replace existing headers

### DIFF
--- a/src/services/Redirects.php
+++ b/src/services/Redirects.php
@@ -285,10 +285,10 @@ class Redirects extends Component
             }
             // Sanitize the URL
             $dest = UrlHelper::sanitizeUrl($dest);
-            // Add any additional headers
+            // Add any additional headers (existing ones will be replaced)
             if (!empty(Retour::$settings->additionalHeaders)) {
                 foreach (Retour::$settings->additionalHeaders as $additionalHeader) {
-                    $response->headers->add($additionalHeader['name'], $additionalHeader['value']);
+                    $response->headers->set($additionalHeader['name'], $additionalHeader['value']);
                 }
             }
             // Redirect the request away;


### PR DESCRIPTION
Currently, if a custom header is already set, Retour adds a second one. In our case, the plugin Upper has already set a default Cache-Control, and Retour is adding a second one. [set()](https://www.yiiframework.com/doc/api/2.0/yii-web-headercollection#set()-detail) replaces the existing header.