### PR TITLE
Fixed an issue where users without the `retour:dashboard` permission would get a 403 when clicking the Retour CP nav item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Retour Changelog
 
+## Unreleased  
+### Fixed  
+* Fixed an issue where clicking the Retour CP nav item would result in a 403 exception if the current user didn't have permission to view the Retour dashboard. Fixes #151
+
 ## 3.1.52 - 2021.04.06
 ### Added
 * Added `make update` to update NPM packages

--- a/src/Retour.php
+++ b/src/Retour.php
@@ -237,6 +237,14 @@ class Retour extends Plugin
                 'url' => 'retour/settings',
             ];
         }
+        // Retour doesn't really have an index page, so if the user can't access any sub nav items, we probably shouldn't show the main sub nav item either
+        if (empty($subNavs)) {
+            return null;
+        }
+        // A single sub nav item is redundant
+        if (count($subNavs) === 1) {
+            $subNavs = [];
+        }
         $navItem = array_merge($navItem, [
             'subnav' => $subNavs,
         ]);
@@ -670,7 +678,7 @@ class Retour extends Plugin
     protected function customAdminCpRoutes(): array
     {
         return [
-            'retour' => 'retour/statistics/dashboard',
+            'retour' => '',
 
             'retour/redirects' => 'retour/redirects/redirects',
             'retour/redirects/<siteHandle:{handle}>' => 'retour/redirects/redirects',

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -1,0 +1,28 @@
+{# @var craft \craft\web\twig\variables\CraftVariable #}
+{#
+/**
+ * Retour plugin for Craft CMS 3.x
+ *
+ * Retour index.twig
+ *
+ * @author    nystudio107
+ * @copyright Copyright (c) 2018 nystudio107
+ * @link      https://nystudio107.com/
+ * @package   Retour
+ * @since     3.x.x
+ */
+#}
+
+{% requirePermission 'accessPlugin-retour' %}
+
+{# Redirect the user to the first sub page they can access #}
+{% if currentUser.can('retour:dashboard') %}
+    {% redirect cpUrl('retour/dashboard') %}
+{% elseif currentUser.can('retour:redirects') %}
+    {% redirect cpUrl('retour/redirects') %}
+{% elseif currentUser.can('retour:settings') %}
+    {% redirect cpUrl('retour/settings') %}
+{% else %}
+    {# ...or throw a 403 if they can't access anything at all #}
+    {% exit 403 %}
+{% endif %}


### PR DESCRIPTION
### Description

This pull request will fix the behaviour described in #151, where Craft will render a 403 exception when the user clicks the Retour CP nav item, if that user lacks the `retour:dashboard` permission (because the `/retour` URL is mapped to `retour/dashboard`.

The fix is implemented by adding a new `index.twig` template to Retour, that redirects the user to the first sub page they actually have access to (or throws a 403 if they can't access any of them). To render that index template, the value for the root CP route `/retour` is changed from `retour/dashboard` to an empty string.

Additionally, if the user only has access to a single Retour sub page (for example, `retour/redirects`) this PR avoids actually rendering the nav item for that page (the nav item will be redundant at that point, as clicking the main Retour nav item will redirect the user to that page anyway).

### Related issues

#151 
