### PR TITLE
Catch Exception thown by Reader::createFromPath() and use cache.

### DIFF
--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -101,13 +101,10 @@ class FileController extends Controller
         $filename = Craft::$app->getRequest()->getRequiredBodyParam('filename');
         $columns = Craft::$app->getRequest()->getRequiredBodyParam('columns');
         $headers = null;
-        $csv = Reader::createFromPath($filename);
+
         try {
+            $csv = Reader::createFromPath($filename);
             $csv->setDelimiter(Retour::$settings->csvColumnDelimiter ?? ',');
-        } catch (Exception $e) {
-            Craft::error($e, __METHOD__);
-        }
-        try {
             $headers = array_flip($csv->fetchOne(0));
         } catch (\Exception $e) {
             // If this throws an exception, try to read the CSV file from the data cache


### PR DESCRIPTION
Quick fix for https://github.com/nystudio107/craft-retour/issues/204, untested.
I'd move the reading and writing to a different class than the controller.