### PR TITLE
Added GraphQL queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Retour Changelog
 
+## Unreleased
+### Added
+* Added the `retourResolveRedirect` GraphQL query that should be used instead of the `retour` query.
+* Added the `retourRedirects` GraphQL query that returns a list of all redirects for a given site.
+
+### Changed
+* The `retour` GraphQL query is now deprecated in favor of the `retourResolveRedirect` query.
+
 ## 3.1.66 - 2021.11.10
 ### Changed
 * Truncate the column names displayed in the Import CSV function to 50 characters to prevent overrun ([#209](https://github.com/nystudio107/craft-retour/issues/209))

--- a/src/gql/queries/RetourQuery.php
+++ b/src/gql/queries/RetourQuery.php
@@ -42,7 +42,26 @@ class RetourQuery extends Query
                 'type' => RetourInterface::getType(),
                 'args' => RetourArguments::getArguments(),
                 'resolve' => RetourResolver::class . '::resolve',
-                'description' => 'This query is used to query for Retour redirects.'
+                'description' => 'This query is used to query for Retour redirects.',
+                'deprecationReason' => 'This query is depreacted and will be removed. You should use `retourResolveRedirect` instead.',
+            ],
+            'retourResolveRedirect' => [
+                'type' => RetourInterface::getType(),
+                'args' => RetourArguments::getArguments(),
+                'resolve' => RetourResolver::class . '::resolve',
+                'description' => 'This query is used to query for Retour redirects.',
+            ],
+            'retourRedirects' => [
+                'type' => Type::listOf(RetourInterface::getType()),
+                'args' => [
+                    'siteId' => [
+                        'name' => 'siteId',
+                        'type' => Type::int(),
+                        'description' => 'The siteId to list all redirects for.'
+                    ],
+                ],
+                'resolve' => RetourResolver::class . '::resolveAll',
+                'description' => 'This query is used to query for all Retour redirects for a site.',
             ],
         ];
     }

--- a/src/gql/resolvers/RetourResolver.php
+++ b/src/gql/resolvers/RetourResolver.php
@@ -46,12 +46,15 @@ class RetourResolver extends Resolver
         $uri = trim($uri === '/' ? '__home__' : $uri);
 
         $redirect = null;
+
         // Strip the query string if `alwaysStripQueryString` is set
         if (Retour::$settings->alwaysStripQueryString) {
             $uri = UrlHelper::stripQueryString($uri);
         }
+
         if (!Retour::$plugin->redirects->excludeUri($uri)) {
             $redirect = Retour::$plugin->redirects->findRedirectMatch($uri, $uri, $siteId);
+
             if ($redirect === null && Craft::$app->getElements()->getElementByUri(trim($uri, '/'), $siteId) === null) {
                 // Increment the stats
                 Retour::$plugin->statistics->incrementStatistics($uri, false, $siteId);
@@ -59,5 +62,24 @@ class RetourResolver extends Resolver
         }
 
         return $redirect;
+    }
+
+    /**
+     * Return all static redirects for a site.
+     *
+     * @param $source
+     * @param array $arguments
+     * @param $context
+     * @param ResolveInfo $resolveInfo
+     * @return array
+     * @throws \craft\errors\SiteNotFoundException
+     */
+    public static function resolveAll($source, array $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        $siteId = $arguments['siteId'] ?? Craft::$app->getSites()->getCurrentSite()->id;
+
+        $redirects = Retour::$plugin->redirects->getAllStaticRedirects(null, $siteId);
+
+        return $redirects;
     }
 }


### PR DESCRIPTION
- Added `retourResolveRedirect` GraphQL query.
- Added `retourRedirects` GraphQL query.
- Deprecated the `retour` GraphQL query.

### Description

Make it possible to query for all redirects via GraphQL and improve the naming of the existing query.