### PR TITLE
feat: lookup exact redirects by DB

### DIFF
--- a/src/services/Redirects.php
+++ b/src/services/Redirects.php
@@ -669,12 +669,14 @@ class Redirects extends Component
                 // Query the db table
                 $query = (new Query())
                     ->from(['{{%retour_static_redirects}}'])
-                    ->where(['!=', 'redirectMatchType' => 'exactmatch'])
+                    ->andWhere(['!=', 'redirectMatchType', 'exactmatch'])
                     ->orderBy('redirectMatchType ASC, redirectSrcMatch ASC, hitCount DESC');
                 if ($siteId) {
                     $query
-                        ->where(['siteId' => $siteId])
-                        ->orWhere(['siteId' => null]);
+                        ->andWhere(['or',
+                            ['siteId' => $siteId],
+                            ['siteId' => null],
+                        ]);
                 }
                 if ($limit) {
                     $query->limit($limit);


### PR DESCRIPTION
We attempted to deploy the "big ol' cache" fix slated for 3.1.69 currently on `develop` and ran in to immediate issues with the size of our cache. This problem manifested itself in two ways,

1. because we have so many static redirects the size of the object being pushed in to the cache exceeded our cache layer's available memory (in this case Redis). I attempted to bump up the cache size but then we ran in to,
2. a memory limit error in PHP because we're trying to push/pull a massively serialized array of DB results. Any time PHP touched that cache we got a PHP memory error because PHP wasn't able to push/pull the object.

We have a potential fix that we're exploring (attached) that offloads any exact match lookups to the database (which is where 99.9999% of our redirects are to begin with). This then causes the DB lookup to run (fast) and then only tries to cache any remaining non-exact (regex or plugin) redirects.

I'm curious your thoughts on if this is viable and any downsides you might see in this.