### PR TITLE
Make $driver nullable

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -28,7 +28,7 @@ class Install extends Migration
     /**
      * @var string The database driver to use
      */
-    public string $driver;
+    public ?string $driver;
 
     // Public Methods
     // =========================================================================


### PR DESCRIPTION
### Description
I'm not sure if this is causing many real world issues, but when running a test suite with `setupCraft` set to `true` on PHP 8.1, this line would throw an error and cause some odd happenings.

### Related issues
https://github.com/craftcms/cms/issues/11984#issuecomment-1257075302