### PR TITLE
Enable statistics

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -39,7 +39,7 @@ return [
     // Should the query string be stripped from the saved statistics source URLs?
     'stripQueryStringFromStats' => true,
 
-    // Should the anonymous ip address of the client causing a 404 be recorded?
+    // Whether statistics should be kept to track how many times a redirect has been followed
     'recordRemoteIp' => true,
 
     // How many stats should be stored
@@ -47,6 +47,9 @@ return [
 
     // Dashboard data live refresh interval
     'refreshIntervalSecs' => 5,
+
+    // Whether statistics should be kept to track how many times a redirect has been followed
+    'enableStatistics' => true,
 
     // Whether the Statistics should be trimmed after each new statistic is recorded
     'automaticallyTrimStatistics' => true,

--- a/src/config.php
+++ b/src/config.php
@@ -39,7 +39,7 @@ return [
     // Should the query string be stripped from the saved statistics source URLs?
     'stripQueryStringFromStats' => true,
 
-    // Whether statistics should be kept to track how many times a redirect has been followed
+    // Should the anonymous ip address of the client causing a 404 be recorded?
     'recordRemoteIp' => true,
 
     // How many stats should be stored

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -98,6 +98,12 @@ class Settings extends Model
     public $automaticallyTrimStatistics = true;
 
     /**
+     * @var bool Whether statistics should be kept to track how many times
+     *      a redirect has been followed
+     */
+    public $enableStatistics = true;
+
+    /**
      * @var int The number of milliseconds required between trimming of
      *      statistics
      */

--- a/src/services/Statistics.php
+++ b/src/services/Statistics.php
@@ -157,6 +157,10 @@ class Statistics extends Component
      */
     public function incrementStatistics(string $url, $handled = false, $siteId = null)
     {
+        if (Retour::$settings->enableStatistics === false) {
+            return;
+        }
+
         $referrer = $remoteIp = null;
         $request = Craft::$app->getRequest();
         if ($siteId === null) {


### PR DESCRIPTION
Adds a new config/setting (no UI for it) to disable statistics. This saves some DB writes on high traffic sites (especially during a launch/cutover where a lot of 302s are hit).

