### PR TITLE
Correct type for siteId argument for `Redirects::findRedirectMatch()`

### DIFF
--- a/src/services/Redirects.php
+++ b/src/services/Redirects.php
@@ -285,7 +285,7 @@ class Redirects extends Component
     /**
      * @param string $fullUrl
      * @param string $pathOnly
-     * @param null $siteId
+     * @param int|null $siteId
      *
      * @return bool|array|null
      */


### PR DESCRIPTION
### Description

When running Vimeo Psalm on my code I get this message:

```php
ERROR: InvalidArgument - ... - Argument 3 of nystudio107\retour\services\Redirects::findRedirectMatch
expects null, but int|null provided (see https://psalm.dev/004)
            $redirect = Retour::$plugin?->redirects->findRedirectMatch($uri, $uri, $siteId);
```

The PHP docblock of `\nystudio107\retour\services\Redirects::findRedirectMatch()` says `@param null $siteId`, while its intent is to pass an integer (or null, or skip the argument).

### Related issues
&ndash;