### PR TITLE
Fix #4 argument in the Db::dropIndexIfExists() in the migration

### DIFF
--- a/src/migrations/m181216_043222_rebuild_indexes.php
+++ b/src/migrations/m181216_043222_rebuild_indexes.php
@@ -26,8 +26,8 @@ class m181216_043222_rebuild_indexes extends Migration
      */
     protected function dropIndexes()
     {
-        Db::dropIndexIfExists('{{%retour_static_redirects}}', 'redirectSrcUrlParsed', true, $this);
-        Db::dropIndexIfExists('{{%retour_redirects}}', 'redirectSrcUrlParsed', true, $this);
+        Db::dropIndexIfExists('{{%retour_static_redirects}}', 'redirectSrcUrlParsed', true, $this->db);
+        Db::dropIndexIfExists('{{%retour_redirects}}', 'redirectSrcUrlParsed', true, $this->db);
     }
 
     /**


### PR DESCRIPTION
### Description
Expected type  https://github.com/craftcms/cms/blob/4.3.7.1/src/helpers/Db.php#L1135
Given type https://github.com/nystudio107/craft-retour/blob/develop-v4/src/migrations/m181216_043222_rebuild_indexes.php#L11



### Related issues
https://github.com/nystudio107/craft-retour/issues/268