### PR TITLE
Enable/disable statistics

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -39,7 +39,7 @@ return [
     // Should the query string be stripped from the saved statistics source URLs?
     'stripQueryStringFromStats' => true,
 
-    // Should the anonymous ip address of the client causing a 404 be recorded?
+    // Whether statistics should be kept to track how many times a redirect has been followed
     'recordRemoteIp' => true,
 
     // How many stats should be stored
@@ -47,6 +47,9 @@ return [
 
     // Dashboard data live refresh interval
     'refreshIntervalSecs' => 5,
+
+    // Whether statistics should be kept to track how many times a redirect has been followed
+    'enableStatistics' => true,
 
     // Whether the Statistics should be trimmed after each new statistic is recorded
     'automaticallyTrimStatistics' => true,

--- a/src/config.php
+++ b/src/config.php
@@ -39,7 +39,7 @@ return [
     // Should the query string be stripped from the saved statistics source URLs?
     'stripQueryStringFromStats' => true,
 
-    // Whether statistics should be kept to track how many times a redirect has been followed
+    // Should the anonymous ip address of the client causing a 404 be recorded?
     'recordRemoteIp' => true,
 
     // How many stats should be stored

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -94,6 +94,12 @@ class Settings extends Model
     public bool $automaticallyTrimStatistics = true;
 
     /**
+     * @var bool Whether statistics should be kept to track how many times
+     *      a redirect has been followed
+     */
+    public $enableStatistics = true;
+
+    /**
      * @var int The number of milliseconds required between trimming of
      *      statistics
      */

--- a/src/services/Statistics.php
+++ b/src/services/Statistics.php
@@ -154,6 +154,10 @@ class Statistics extends Component
      */
     public function incrementStatistics(string $url, bool $handled = false, $siteId = null): void
     {
+        if (Retour::$settings->enableStatistics === false) {
+            return;
+        }
+
         $referrer = $remoteIp = null;
         $request = Craft::$app->getRequest();
         if ($siteId === null) {


### PR DESCRIPTION
### Description

Adds a flag to control whether you want statistics enabled. The use case for disabling this is to prevent against DDoS attacks that hit a long tail of (uncached) 404s causing an abundance of writes to the database.

### Related issues

Looked through the Issues tab and didn't see anything directly related. Some performance issues but most were resolved by some of the indexes you've added over the years.