### PR TITLE
Fixes issue where only first line of uploaded CSV is saved in cache in load balanced environment

### DIFF
--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -221,7 +221,10 @@ class FileController extends Controller
             $cache = Craft::$app->getCache();
             $fileHandle = fopen($filePath, 'r');
             if ($fileHandle) {
-                $fileContents = fgets($fileHandle);
+                $fileContents = null;
+                while(feof($fileHandle) !== true) {
+                    $fileContents .= fgets($fileHandle);
+                }
                 if ($fileContents) {
                     $cache->set($filePath, $fileContents);
                 }

--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -218,17 +218,9 @@ class FileController extends Controller
             $filePath = Craft::$app->getPath()->getTempPath() . DIRECTORY_SEPARATOR . $filename;
             $file->saveAs($filePath, false);
             // Also save the file to the cache as a backup way to access it
-            $cache = Craft::$app->getCache();
-            $fileHandle = fopen($filePath, 'r');
-            if ($fileHandle) {
-                $fileContents = null;
-                while(feof($fileHandle) !== true) {
-                    $fileContents .= fgets($fileHandle);
-                }
-                if ($fileContents) {
-                    $cache->set($filePath, $fileContents);
-                }
-                fclose($fileHandle);
+            $fileContents = @file_get_contents($filePath);
+            if ($fileContents) {
+                Craft::$app->getCache()->set($filePath, $fileContents);
             }
             // Read in the headers
             $csv = Reader::createFromPath($file->tempName);


### PR DESCRIPTION
Fixes https://github.com/nystudio107/craft-retour/issues/284

### Description

It appears the `fgets` method only gets the first line of the uploaded file unless it is used in a loop. Example here: https://stackoverflow.com/a/31152028